### PR TITLE
Fixed exclusion problem

### DIFF
--- a/tools/qacompiler/qa_checks_r.dita
+++ b/tools/qacompiler/qa_checks_r.dita
@@ -37,6 +37,18 @@
         </tbody>
       </tgroup>
     </table>
+    <section>
+      <title>Exclusions</title>
+      <sl id="excludes">
+        <sli>codeblock</sli>
+        <sli>cmdname</sli>
+        <sli>draft-comment</sli>
+        <sli>filepath</sli>
+        <sli>msgblock </sli>
+        <sli>uicontrol</sli>
+        <sli>varname</sli>
+      </sl>
+    </section>
     <properties id="markup">
       <prophead>
         <proptypehd>Severity</proptypehd>

--- a/tools/qacompiler/qa_compiler.xsl
+++ b/tools/qacompiler/qa_compiler.xsl
@@ -1,42 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs"
-  version="2.0">
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs" version="2.0">
   <xsl:output indent="yes" method="xml" />
-  <xsl:variable name="excludes">codeblock or draft-comment or filepath or
-    shortdesc or uicontrol or varname</xsl:variable>
   <xsl:template match="/">
+    <xsl:variable name="excludes">
+      <xsl:for-each select="distinct-values(//sl[@id = 'excludes']/sli)">
+        <xsl:sort order="ascending" select="normalize-space(.)" />
+        <xsl:value-of select="concat('parent::', (normalize-space(.)))" />
+        <xsl:if test="position() &lt; last()">
+          <xsl:text> or </xsl:text>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
     <xsl:element name="xsl:stylesheet">
       <xsl:attribute name="version">2.0</xsl:attribute>
-      <xsl:element name="xsl:variable">
-         <xsl:attribute name="name">excludes</xsl:attribute>        
-        <xsl:value-of select="$excludes"/>
-      </xsl:element>
       <xsl:element name="xsl:template">
         <xsl:attribute name="name">term</xsl:attribute>
         <xsl:apply-templates
-          select="descendant::*[contains(@class, ' reference/properties ')]/*[contains(@class, ' reference/property ')][descendant::*[contains(@class, ' reference/propvalue ')]]"
-         />
+          select="descendant::*[contains(@class, ' reference/properties ')]/*[contains(@class, ' reference/property ')][descendant::*[contains(@class, ' reference/propvalue ')]]">
+          <xsl:with-param name="excludes">
+            <xsl:value-of select="$excludes" />
+          </xsl:with-param>
+        </xsl:apply-templates>
       </xsl:element>
     </xsl:element>
   </xsl:template>
 
   <!-- XPath expressions -->
   <xsl:template match="*[contains(@class, ' reference/property ')]">
+    <xsl:param name="excludes" required="no" />
     <xsl:element name="xsl:if">
       <xsl:attribute name="test">
         <xsl:choose>
           <xsl:when
             test="*[contains(@class, ' reference/propvalue ')][descendant::*[contains(@class, ' pr-d/codeph ')]]">
             <!-- It is an XPath expression -->
-            <xsl:value-of select="*[contains(@class, ' reference/propvalue ')]"
+            <xsl:value-of
+              select="replace(normalize-space(*[contains(@class, ' reference/propvalue ')]), '\$excludes', concat('not(', $excludes, ')'))"
              />
           </xsl:when>
           <xsl:otherwise>
             <!-- Assume it is a terminology check -->
-            <xsl:text>descendant::*[not(</xsl:text>
-            <xsl:value-of select="replace($excludes, '\s+', ' ')" />
-            <xsl:text>)]/text()[matches(.,'</xsl:text>
+            <xsl:text>.//*/text()</xsl:text>
+            <xsl:if test="$excludes">
+              <xsl:value-of select="concat('[not(', $excludes, ')]')" />
+            </xsl:if>
+            <xsl:text>[matches(.,'</xsl:text>
             <xsl:value-of select="*[contains(@class, ' reference/propvalue ')]" />
             <xsl:text>', 'i')]</xsl:text>
           </xsl:otherwise>
@@ -45,12 +54,11 @@
 
       <xsl:element name="data">
         <xsl:attribute name="type">msg</xsl:attribute>
-        <xsl:attribute name="ouputclass">
-          <xsl:value-of select="replace(ancestor::properties/@id, '_', ' ')"/>
+        <xsl:attribute name="outputclass">
+          <xsl:value-of select="replace(ancestor::properties/@id, '_', ' ')" />
         </xsl:attribute>
         <xsl:attribute name="importance">
-          <xsl:value-of
-            select="lower-case(*[contains(@class, ' reference/proptype ')])" />
+          <xsl:value-of select="lower-case(*[contains(@class, ' reference/proptype ')])" />
         </xsl:attribute>
         <xsl:value-of select="*[contains(@class, ' reference/propdesc ')]" />
       </xsl:element>


### PR DESCRIPTION
Changed XPath expressions to the following form so that exclusions work:

```
".//*/text()[not(parent::cmdname or parent::codeblock)][matches(.,'term', 'i')]"
```

Now you can specify the exclusion lists in the reference topic that defines the terminology checks.
